### PR TITLE
Revert "Revert "O0764 :: When user send message having text then getting extra blank area added at widget""

### DIFF
--- a/src/app/chat/chat-widget/components/selected-channel/components/in-message/in-message.component.html
+++ b/src/app/chat/chat-widget/components/selected-channel/components/in-message/in-message.component.html
@@ -201,7 +201,7 @@
                 messages?.message_type !== 'interactive' &&
                 messages?.content?.text
             "
-            [innerHTML]="messages.content.text | replace: '\n':'</br>' | whatsAppInlineStyleFormat | linkify"
+            [innerHTML]="messages.content.text | whatsAppInlineStyleFormat | linkify"
             class="input-msg-break "
         ></p>
 


### PR DESCRIPTION
Reverts Walkover-Web-Solution/chat-widget#56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the chat interface so that multiline messages now display without automatically inserting line breaks, offering a more consistent text appearance in the conversation view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->