### PR TITLE
fix: prevent auto-response messages from rendering in the default bot message UI component

### DIFF
--- a/components/Interface-Chatbot/Messages/HumanOrBotMessage.tsx
+++ b/components/Interface-Chatbot/Messages/HumanOrBotMessage.tsx
@@ -223,7 +223,7 @@ const MessageContent = React.memo(({ message, isBot }: { message: any; isBot: bo
                 );
 
             default:
-                if (isBot) {
+                if (isBot && !message?.is_auto_response) {
                     return (
                         <InterfaceMarkdown>
                             {message?.content}


### PR DESCRIPTION
fix: prevent auto-response messages from rendering in the default bot message UI component